### PR TITLE
Fix activate path for pwsh on MacOS

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -27,3 +27,5 @@ prune .azure-pipelines
 prune .github
 prune pipenv/vendor/importlib_metadata/tests
 prune pipenv/vendor/importlib_resources/tests
+
+exclude examples/*

--- a/news/6216.vendor.rst
+++ b/news/6216.vendor.rst
@@ -1,0 +1,1 @@
+Remove click.echo from exceptions.py

--- a/news/6318.bugfix.rst
+++ b/news/6318.bugfix.rst
@@ -1,0 +1,1 @@
+Running "pipenv shell" on MacOS in Powershell (pwsh) references incorrect Activate.ps1

--- a/news/6327.bugfix.rst
+++ b/news/6327.bugfix.rst
@@ -1,0 +1,1 @@
+Fix incorrect path for 'pipenv shell'

--- a/news/6329.bugfix.rst
+++ b/news/6329.bugfix.rst
@@ -1,0 +1,1 @@
+Fix license declaration for PyPI

--- a/pipenv/exceptions.py
+++ b/pipenv/exceptions.py
@@ -167,12 +167,8 @@ class PipfileNotFound(PipenvFileError):
     def __init__(self, filename="Pipfile", extra=None, **kwargs):
         extra = kwargs.pop("extra", [])
         message = "{} {}".format(
-            click.style("Aborting!", bold=True, fg="red"),
-            click.style(
-                "Please ensure that the file exists and is located in your"
-                " project root directory.",
-                bold=True,
-            ),
+            "[bold red]Aborting![/bold red]",
+            "[bold]Please ensure that the file exists and is located in your project root directory.[/bold]",
         )
         super().__init__(filename, message=message, extra=extra, **kwargs)
 

--- a/pipenv/exceptions.py
+++ b/pipenv/exceptions.py
@@ -293,16 +293,6 @@ class InstallError(PipenvException):
         PipenvException.__init__(self, message=message, extra=extra, **kwargs)
 
 
-class CacheError(PipenvException):
-    def __init__(self, path, **kwargs):
-        message = "{} {}\n{}".format(
-            click.style("Corrupt cache file", fg="cyan"),
-            click.style(f"{path!s}", fg="reset", bg="reset"),
-            click.style('Consider trying "pipenv lock --clear" to clear the cache.'),
-        )
-        PipenvException.__init__(self, message=message)
-
-
 class DependencyConflict(PipenvException):
     def __init__(self, message):
         extra = [

--- a/pipenv/exceptions.py
+++ b/pipenv/exceptions.py
@@ -177,9 +177,9 @@ class LockfileNotFound(PipenvFileError):
     def __init__(self, filename="Pipfile.lock", extra=None, **kwargs):
         extra = kwargs.pop("extra", [])
         message = "{} {} {}".format(
-            click.style("You need to run", bold=True),
-            click.style("$ pipenv lock", bold=True, fg="red"),
-            click.style("before you can continue.", bold=True),
+            "[bold]You need to run[/bold]",
+            "[bold red]$ pipenv lock[/bold red]",
+            "[bold]before you can continue.[/bold]"
         )
         super().__init__(filename, message=message, extra=extra, **kwargs)
 

--- a/pipenv/exceptions.py
+++ b/pipenv/exceptions.py
@@ -187,7 +187,7 @@ class LockfileNotFound(PipenvFileError):
 class DeployException(PipenvUsageError):
     def __init__(self, message=None, **kwargs):
         if not message:
-            message = click.style("Aborting deploy", bold=True)
+            message = "[bold]Aborting deploy[/bold]"
         extra = kwargs.pop("extra", [])
         PipenvUsageError.__init__(self, message=message, extra=extra, **kwargs)
 

--- a/pipenv/exceptions.py
+++ b/pipenv/exceptions.py
@@ -141,14 +141,14 @@ class PipenvUsageError(UsageError):
 
 
 class PipenvFileError(FileError):
-    formatted_message = "{} {{}} {{}}".format(click.style("ERROR:", fg="red", bold=True))
+    formatted_message = "{} {{}} {{}}".format("[bold red]ERROR:[/bold red]")
 
     def __init__(self, filename, message=None, **kwargs):
         extra = kwargs.pop("extra", [])
         if not message:
-            message = click.style("Please ensure that the file exists!", bold=True)
+            message = "[bold]Please ensure that the file exists![/bold]"
         message = self.formatted_message.format(
-            click.style(f"{filename} not found!", bold=True), message
+            f"[bold]{filename} not found![/bold]", message
         )
         FileError.__init__(self, filename=filename, hint=message, **kwargs)
         self.extra = extra

--- a/pipenv/exceptions.py
+++ b/pipenv/exceptions.py
@@ -260,18 +260,18 @@ class UninstallError(PipenvException):
     def __init__(self, package, command, return_values, return_code, **kwargs):
         extra = [
             "{} {}".format(
-                click.style("Attempted to run command: ", fg="cyan"),
-                click.style(f"$ {command!r}", bold=True, fg="yellow"),
+                "[cyan]Attempting to run command: [/cyan]",
+                f"[bold yellow]$ {command!r}[/bold yellow]",
             )
         ]
         extra.extend(
-            [click.style(line.strip(), fg="cyan") for line in return_values.splitlines()]
+            [f"[cyan]{line.strip()}[/cyan]" for line in return_values.splitlines()]
         )
         if isinstance(package, (tuple, list, set)):
             package = " ".join(package)
         message = "{!s} {!s}...".format(
-            click.style("Failed to uninstall package(s)", fg="reset"),
-            click.style(f"{package}!s", bold=True, fg="yellow"),
+            "Failed to uninstall package(s)",
+            f"[bold yellow]{package}!s[/bold yellow]",
         )
         self.exit_code = return_code
         PipenvException.__init__(self, message=message, extra=extra)

--- a/pipenv/exceptions.py
+++ b/pipenv/exceptions.py
@@ -179,7 +179,7 @@ class LockfileNotFound(PipenvFileError):
         message = "{} {} {}".format(
             "[bold]You need to run[/bold]",
             "[bold red]$ pipenv lock[/bold red]",
-            "[bold]before you can continue.[/bold]"
+            "[bold]before you can continue.[/bold]",
         )
         super().__init__(filename, message=message, extra=extra, **kwargs)
 
@@ -206,12 +206,12 @@ class SystemUsageError(PipenvOptionsError):
         extra += [
             "{}: --system is intended to be used for Pipfile installation, "
             "not installation of specific packages. Aborting.".format(
-                click.style("Warning", bold=True, fg="red")
+                "[bold red]Warning[/bold /red]",
             ),
         ]
         if message is None:
             message = "{} --deploy flag".format(
-                click.style("See also: {}", fg="cyan"),
+                "[cyan]See also: {}[/cyan]",
             )
         super().__init__(option_name, message=message, ctx=ctx, extra=extra, **kwargs)
 

--- a/pipenv/exceptions.py
+++ b/pipenv/exceptions.py
@@ -283,11 +283,11 @@ class InstallError(PipenvException):
         package_message = ""
         if package is not None:
             package_message = "Couldn't install package: {}\n".format(
-                click.style(f"{package!s}", bold=True)
+                f"[bold]{package!s}[/bold]"
             )
         message = "{} {}".format(
             f"{package_message}",
-            click.style("Package installation failed...", fg="yellow"),
+            "[yellow]Package installation failed...[/yellow]",
         )
         extra = kwargs.pop("extra", [])
         PipenvException.__init__(self, message=message, extra=extra, **kwargs)

--- a/pipenv/shells.py
+++ b/pipenv/shells.py
@@ -61,7 +61,7 @@ def _get_activate_script(cmd, venv):
 
     if suffix == "nu":
         return f"overlay use {venv_location}"
-    elif suffix == ".ps1":
+    elif suffix == ".ps1" and os.name == "nt":
         return f". {venv_location}\\Scripts\\Activate.{suffix}"
 
     # The leading space can make history cleaner in some shells.

--- a/pipenv/shells.py
+++ b/pipenv/shells.py
@@ -62,7 +62,7 @@ def _get_activate_script(cmd, venv):
     if suffix == "nu":
         return f"overlay use {venv_location}"
     elif suffix == ".ps1":
-        return f". {venv_location}\\Scripts\\Activate.{suffix}"
+        return f". {venv_location}\\Scripts\\Activate{suffix}"
 
     # The leading space can make history cleaner in some shells.
     return f" {command} {venv_location}/bin/activate{suffix}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
 name = "pipenv"
 description = "Python Development Workflow for Humans."
 readme = "README.md"
-license = { file = "LICENSE" }
+license = {text = "MIT License (MIT)"}
 authors = [
   { name = "Pipenv maintainer team", email = "distutils-sig@python.org" },
 ]


### PR DESCRIPTION
### The issue

Running "pipenv shell" on MacOS in Powershell (pwsh) references incorrect Activate.ps1

### The fix

Adds a check for os.name and removes the extra '.' before the extension

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.